### PR TITLE
Update memory limit of generateThumbnail to 512MB

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ gcloud functions deploy generateThumbnail \
   --trigger-resource <Bucket Name> \
   --trigger-event google.storage.object.finalize \
   --runtime nodejs10 \
+  --memory 512MB \
   --region asia-northeast1
 
 gcloud functions deploy notifyFeedback \

--- a/cloudbuild.prod.yaml
+++ b/cloudbuild.prod.yaml
@@ -8,5 +8,5 @@ steps:
       - "-c"
       - |
         gcloud kms decrypt --ciphertext-file=.env.yaml.enc --plaintext-file=.env.yaml --location=global --keyring=qoodish --key=qoodish
-        gcloud functions deploy generateThumbnail --trigger-resource qoodish --trigger-event google.storage.object.finalize --runtime nodejs10 --region asia-northeast1
+        gcloud functions deploy generateThumbnail --trigger-resource qoodish --trigger-event google.storage.object.finalize --runtime nodejs10 --memory 512MB --region asia-northeast1
         gcloud functions deploy notifyFeedback --trigger-event providers/cloud.firestore/eventTypes/document.create --trigger-resource projects/$PROJECT_ID/databases/default/documents/feedbacks/{feedbackId} --runtime nodejs10 --region asia-northeast1 --env-vars-file .env.yaml


### PR DESCRIPTION
アップロードした画像のサイズが大きいとサムネイル生成処理が memory limit に達して力尽きるという問題が起きていたため、memory limit を 256MB → 512MB に更新しました。